### PR TITLE
Add copy PR link command; rebind comment to M

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ Select a PR and press Enter to check it out locally.
 | `r` | Filter to your review requests |
 | `o` | Open PR in browser |
 | `O` | Open all PRs needing review in browser |
+| `c` | Copy PR link to clipboard |
 | `d` | Review PR diff with [hunk](https://github.com/modem-dev/hunk) (split by default; press `1`/`2`/`0` inside hunk to flip layout) |
 | `A` | Approve PR (with `y`/`n` confirm) |
 | `D` | Request changes — opens `$EDITOR` for body |
-| `C` | Comment on PR — opens `$EDITOR` for body |
+| `M` | Comment on PR — opens `$EDITOR` for body |
 | `Enter` | Checkout PR |
 | `?` | Toggle full help overlay |
 | `q` / `Esc` | Quit |

--- a/main.go
+++ b/main.go
@@ -1222,7 +1222,7 @@ func (m model) handleNormalInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "C":
+	case "M":
 		if m.actionPending || m.loadingDiff {
 			return m, nil
 		}
@@ -1241,6 +1241,20 @@ func (m model) handleNormalInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			pr := m.filtered[m.cursor]
 			url := fmt.Sprintf("https://github.com/%s/%s/pull/%d", pr.Repository.Owner.Login, pr.Repository.Name, pr.Number)
 			exec.Command("open", "-g", url).Start()
+		}
+		return m, nil
+
+	case "c":
+		if len(m.filtered) > 0 && m.cursor < len(m.filtered) {
+			pr := m.filtered[m.cursor]
+			url := fmt.Sprintf("https://github.com/%s/%s/pull/%d", pr.Repository.Owner.Login, pr.Repository.Name, pr.Number)
+			cmd := exec.Command("pbcopy")
+			cmd.Stdin = strings.NewReader(url)
+			if err := cmd.Run(); err != nil {
+				m.actionStatus = "Error copying link: " + err.Error()
+			} else {
+				m.actionStatus = fmt.Sprintf("✓ Copied PR #%d link", pr.Number)
+			}
 		}
 		return m, nil
 
@@ -1403,9 +1417,10 @@ func (m model) helpView() string {
 			{"d", "Review diff (hunk: 1=split · 2=stack · 0=auto)"},
 			{"A", "Approve"},
 			{"D", "Request changes"},
-			{"C", "Comment"},
+			{"M", "Comment"},
 			{"o", "Open in browser"},
 			{"O", "Open all needing review"},
+			{"c", "Copy PR link"},
 		}},
 		{"Other", [][2]string{
 			{"R", "Refresh PR list"},


### PR DESCRIPTION
## Summary
- `c` copies the current PR's GitHub URL to the clipboard via `pbcopy`.
- Comment moves from `C` to `M` to free up `c` for copy. `M` keeps review-action keys uppercase alongside `A` (approve) and `D` (request changes).
- Help overlay and README updated.

## Test plan
- [ ] Highlight a PR, press `c`, confirm URL is on the clipboard and status shows "✓ Copied PR #N link"
- [ ] Press `M`, confirm `$EDITOR` opens for a comment body and submission still works
- [ ] Press `?`, confirm new bindings appear in the help overlay